### PR TITLE
Add dependency declaration

### DIFF
--- a/pdf-continuous-scroll-mode.el
+++ b/pdf-continuous-scroll-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Daniel Laurens Nicolai <dalanicolai@gmail.com>
 ;; Version: 0
 ;; Keywords: pdf-tools,
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1") (pdf-tools "1.0"))
 ;; URL: https://github.com/dalanicolai/pdf-continuous-scroll-mode.el
 
 


### PR DESCRIPTION
While the package.el comments declare no other dependency than Emacs
itself, lines 30 and 31 require `pdf-tools` and `pdf-annot`, both from
the `pdf-tools` package.

This commit adds `pdf-tools` as a dependency to the package so
package.el and other package managers can correctly install it when
installing `pdf-continuous-scroll-mode`.